### PR TITLE
workaround: #3

### DIFF
--- a/src/Services/OcrService.cs
+++ b/src/Services/OcrService.cs
@@ -5,6 +5,7 @@ using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Windows.Graphics.Imaging;
 using Windows.Media.Ocr;
@@ -13,24 +14,19 @@ using StellasoraPotentialOverlay.Models;
 
 namespace StellasoraPotentialOverlay.Services;
 
-public class OcrService : IDisposable
-{
+public class OcrService : IDisposable {
     private OcrEngine? _ocrEngine;
     private bool _isInitialized = false;
 
-    public async Task<bool> InitializeAsync()
-    {
+    public async Task<bool> InitializeAsync() {
         return await Task.Run(() => {
-            try
-            {
+            try {
                 System.Diagnostics.Debug.WriteLine("[OCR] 初期化開始...");
                 var language = new Windows.Globalization.Language("ja");
-                if (!OcrEngine.IsLanguageSupported(language))
-                {
+                if (!OcrEngine.IsLanguageSupported(language)) {
                     _ocrEngine = OcrEngine.TryCreateFromUserProfileLanguages();
                 }
-                else
-                {
+                else {
                     _ocrEngine = OcrEngine.TryCreateFromLanguage(language);
                 }
 
@@ -39,16 +35,14 @@ public class OcrService : IDisposable
                 _isInitialized = true;
                 return true;
             }
-            catch (Exception ex)
-            {
+            catch (Exception ex) {
                 System.Diagnostics.Debug.WriteLine($"[OCR] 初期化エラー: {ex.Message}");
                 return false;
             }
         });
     }
 
-    public async Task<List<OcrDetectionResult>> RecognizeTextAsync(Bitmap capturedImage, AppConfig config)
-    {
+    public async Task<List<OcrDetectionResult>> RecognizeTextAsync(Bitmap capturedImage, AppConfig config) {
         var results = new List<OcrDetectionResult>();
 
         if (!_isInitialized || _ocrEngine == null || capturedImage == null)
@@ -58,10 +52,8 @@ public class OcrService : IDisposable
         int windowHeight = capturedImage.Height;
         List<double> xs = new List<double> { config.LeftX, config.CenterX, config.RightX, config.X2LeftX, config.X2RightX };
 
-        foreach (var x in xs)
-        {
-            try
-            {
+        foreach (var x in xs) {
+            try {
                 // 1. 広めの領域を切り出し
                 var rect = CalculateRect(x, config.CommonY, config.CommonWidth, config.CommonHeight, windowWidth, windowHeight);
                 if (rect.IsEmpty) continue;
@@ -82,12 +74,10 @@ public class OcrService : IDisposable
                     .OrderBy(l => l.Words[0].BoundingRect.Y) // Y座標順（上から下へ）
                     .FirstOrDefault();
 
-                if (firstLine != null && !string.IsNullOrWhiteSpace(firstLine.Text))
-                {
+                if (firstLine != null && !string.IsNullOrWhiteSpace(firstLine.Text)) {
                     // マッチング
                     var matchedTarget = FindMatchingTarget(firstLine.Text, config.CharacterTargets);
-                    if (matchedTarget != null)
-                    {
+                    if (matchedTarget != null) {
                         results.Add(new OcrDetectionResult
                         {
                             RecognizedText = firstLine.Text,
@@ -101,8 +91,7 @@ public class OcrService : IDisposable
                     }
                 }
             }
-            catch
-            {
+            catch {
                 continue;
             }
         }
@@ -121,8 +110,7 @@ public class OcrService : IDisposable
         List<double> xs = new List<double> { config.LeftX, config.CenterX, config.RightX, config.X2LeftX, config.X2RightX };
         int regionId = 0;
 
-        foreach (var x in xs)
-        {
+        foreach (var x in xs) {
             regionId++;
             var rect = CalculateRect(x, config.CommonY, config.CommonWidth, config.CommonHeight, windowWidth, windowHeight);
             if (rect.IsEmpty) continue;
@@ -134,29 +122,25 @@ public class OcrService : IDisposable
 
             string displayText = "[認識なし]";
             
-            if (ocrResult != null && ocrResult.Lines.Count > 0)
-            {
+            if (ocrResult != null && ocrResult.Lines.Count > 0) {
                 // Y座標順にソートしてデバッグ表示
                 var lines = ocrResult.Lines
                     .Where(l => l.Words.Count > 0)
                     .OrderBy(l => l.Words[0].BoundingRect.Y)
                     .ToList();
 
-                if (lines.Count > 0)
-                {
+                if (lines.Count > 0) {
                     var firstLine = lines[0].Text;
                     var otherLines = string.Join(", ", lines.Skip(1).Select(l => l.Text));
                     
                     displayText = $"採用: {firstLine}";
-                    if (!string.IsNullOrEmpty(otherLines))
-                    {
+                    if (!string.IsNullOrEmpty(otherLines)) {
                         displayText += $"\n(無視: {otherLines})";
                     }
                 }
             }
 
-            results.Add(new OcrDebugResult
-            {
+            results.Add(new OcrDebugResult {
                 RecognizedText = displayText,
                 RegionId = regionId,
                 RegionName = $"Region {regionId}",
@@ -181,8 +165,7 @@ public class OcrService : IDisposable
         int scale = 3;
         var dest = new Bitmap(region.Width * scale, region.Height * scale, PixelFormat.Format32bppArgb);
         
-        using (var g = Graphics.FromImage(dest))
-        {
+        using (var g = Graphics.FromImage(dest)) {
             g.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.HighQualityBicubic;
             g.DrawImage(region, 0, 0, dest.Width, dest.Height);
         }
@@ -191,14 +174,12 @@ public class OcrService : IDisposable
         var rectData = new Rectangle(0, 0, dest.Width, dest.Height);
         var data = dest.LockBits(rectData, ImageLockMode.ReadWrite, PixelFormat.Format32bppArgb);
 
-        unsafe
-        {
+        unsafe {
             byte* ptr = (byte*)data.Scan0;
             int totalBytes = data.Stride * dest.Height;
             int bytesPerPixel = 4; // ARGB
 
-            for (int i = 0; i < totalBytes; i += bytesPerPixel)
-            {
+            for (int i = 0; i < totalBytes; i += bytesPerPixel) {
                 // B, G, R の順
                 byte b = ptr[i];
                 byte g = ptr[i + 1];
@@ -208,14 +189,12 @@ public class OcrService : IDisposable
                 // それ以外は白にする
                 bool isDarkText = (r < threshold && g < threshold && b < threshold);
 
-                if (isDarkText)
-                {
+                if (isDarkText) {
                     ptr[i] = 0;     // B
                     ptr[i + 1] = 0; // G
                     ptr[i + 2] = 0; // R
                 }
-                else
-                {
+                else {
                     ptr[i] = 255;     // B
                     ptr[i + 1] = 255; // G
                     ptr[i + 2] = 255; // R
@@ -228,8 +207,7 @@ public class OcrService : IDisposable
         return dest;
     }
 
-    private Rectangle CalculateRect(double xRatio, double yRatio, double wRatio, double hRatio, int totalW, int totalH)
-    {
+    private Rectangle CalculateRect(double xRatio, double yRatio, double wRatio, double hRatio, int totalW, int totalH) {
         int x = (int)(xRatio * totalW);
         int y = (int)(yRatio * totalH);
         int w = (int)(wRatio * totalW);
@@ -243,8 +221,7 @@ public class OcrService : IDisposable
         return new Rectangle(x, y, w, h);
     }
 
-    private async Task<OcrResult?> RecognizeBitmapAsync(Bitmap bitmap)
-    {
+    private async Task<OcrResult?> RecognizeBitmapAsync(Bitmap bitmap) {
         if (_ocrEngine == null) return null;
 
         using var memoryStream = new MemoryStream();
@@ -260,31 +237,38 @@ public class OcrService : IDisposable
         return await _ocrEngine.RecognizeAsync(softwareBitmap);
     }
 
-    private CharacterTarget? FindMatchingTarget(string recognizedText, List<CharacterTarget> targets)
-    {
-        var cleanedText = recognizedText
-            .Replace(" ", "")
-            .Replace("　", "")
-            .Replace(".", "")
-            .Replace(",", "")
-            .Replace("'", "")
-            .Replace("’", "");
+    /// <summary>
+    /// OCR結果のテキストと一致する素質を返す
+    /// </summary>
+    private CharacterTarget? FindMatchingTarget(string recognizedText, List<CharacterTarget> targets, bool useFuzzySearch = true) {
+        // ノイズ除去
+        string cleanedRecognizedText = Regex.Replace(recognizedText, @"[ 　.,'’]", "");
+        // ぱ（パ）行、ば（バ）行をは（ハ）行に寄せる
+        var diacriticMap = new Dictionary<char, char> {
+            {'ば','は'}, {'ぱ','は'}, {'バ','ハ'}, {'パ','ハ'},
+            {'び','ひ'}, {'ぴ','ひ'}, {'ビ','ヒ'}, {'ピ','ヒ'},
+            {'ぶ','ふ'}, {'ぷ','ふ'}, {'ブ','フ'}, {'プ','フ'},
+            {'べ','へ'}, {'ぺ','へ'}, {'ベ','ヘ'}, {'ペ','ヘ'},
+            {'ぼ','ほ'}, {'ぽ','ほ'}, {'ボ','ホ'}, {'ポ','ホ'}
+        };
+        string Normalize(string text) => string.Concat(text.Select(c => diacriticMap.GetValueOrDefault(c, c)));
+        string normalizedRecognizedText = Normalize(cleanedRecognizedText);
 
-        foreach (var target in targets.Where(t => t.IsEnabled))
-        {
-            var cleanedSearchText = target.SearchText.Replace(" ", "").Replace("　", "");
-            if (string.IsNullOrEmpty(cleanedSearchText)) continue;
-
-            if (cleanedText.Contains(cleanedSearchText))
-            {
-                return target;
+        // 有効にチェックが入っている素質を検索
+        foreach (var target in targets.Where(t => t.IsEnabled)) {
+            // 空文字の場合はスキップ
+            if (string.IsNullOrEmpty(target.SearchText)) continue;
+            // そのまま比較
+            if (cleanedRecognizedText.Contains(target.SearchText)) return target;
+            // ぱ（パ）行、ば（バ）行をは（ハ）行に寄せて比較
+            if (useFuzzySearch) {
+                if (normalizedRecognizedText.Contains(Normalize(target.SearchText))) return target;
             }
         }
         return null;
     }
 
-    public void Dispose()
-    {
+    public void Dispose() {
         _ocrEngine = null;
         _isInitialized = false;
         GC.SuppressFinalize(this);


### PR DESCRIPTION
暫定対応として、OCRテキストと素質名の比較において、ぱ（パ）行、ば（バ）行をは行に寄せて比較するように修正。